### PR TITLE
[M68K] add move.{b,w,l} decoding

### DIFF
--- a/arch/M68K/M68KDisassembler.c
+++ b/arch/M68K/M68KDisassembler.c
@@ -302,12 +302,20 @@ bool M68K_getInstruction(csh ud, const uint8_t* code, size_t code_len, MCInst* i
 	s_disassemblyBuffer = (uint8_t*)code;
 	s_baseAddress = (uint32_t)address;
 
-	printf("getInstruction: %d %p\n", (int)address, s_disassemblyBuffer);
 
-	s = m68k_disassemble(instr, address, M68K_CPU_TYPE_68040);
+	s = m68k_disassemble(instr, address, M68K_CPU_TYPE_68000);
+	printf("getInstruction: %p %d %p\n", (void*)address, s, s_disassemblyBuffer);
 
+	
+	
 	if (s == 0)
 		return false;
+
+
+	SStream ss;
+	SStream_Init(&ss);
+	M68K_printInst(instr, &ss, info);
+	printf("%s\n", ss.buffer);
 
 	*size = (uint16_t)s;
 

--- a/arch/M68K/M68Kdasm.c
+++ b/arch/M68K/M68Kdasm.c
@@ -3506,7 +3506,9 @@ static void d68000_tas(void)
 
 static void d68000_trap(void)
 {
-	sprintf(g_dasm_str, "trap    #$%x", g_cpu_ir&0xf);
+	build_bcc(0, g_cpu_ir&0xf);
+	MCInst_setOpcode(g_inst, M68K_INS_TRAP);
+	//sprintf(g_dasm_str, "trap    #$%x", g_cpu_ir&0xf);
 }
 
 static void d68020_trapcc_0(void)

--- a/arch/M68K/M68Kdasm.c
+++ b/arch/M68K/M68Kdasm.c
@@ -1090,6 +1090,22 @@ static void build_ea_a(int opcode, uint8_t size)
 	op1->reg = M68K_REG_A0 + ((g_cpu_ir >> 9) & 7);
 }
 
+static void build_ea_ea(int opcode, int size)
+{
+	MCInst_setOpcode(g_inst, opcode);
+
+	cs_m68k* info = &g_inst->flat_insn->detail->m68k;
+
+	info->op_count = 2;
+	info->op_size = size;
+
+	cs_m68k_op* op0 = &info->operands[0];
+	cs_m68k_op* op1 = &info->operands[1];
+
+	get_ea_mode_op(op0, g_cpu_ir, size);
+	get_ea_mode_op(op1, (((g_cpu_ir>>9) & 7) | ((g_cpu_ir>>3) & 0x38)), size);
+}
+
 static void build_pi_pi(int opcode, int size)
 {
 	MCInst_setOpcode(g_inst, opcode);
@@ -2433,20 +2449,23 @@ static void d68000_lsl_ea(void)
 
 static void d68000_move_8(void)
 {
-	char* str = get_ea_mode_str_8(g_cpu_ir);
-	sprintf(g_dasm_str, "move.b  %s, %s", str, get_ea_mode_str_8(((g_cpu_ir>>9) & 7) | ((g_cpu_ir>>3) & 0x38)));
+	build_ea_ea(M68K_INS_MOVE, 1);
+	//char* str = get_ea_mode_str_8(g_cpu_ir);
+	//sprintf(g_dasm_str, "move.b  %s, %s", str, get_ea_mode_str_8(((g_cpu_ir>>9) & 7) | ((g_cpu_ir>>3) & 0x38)));
 }
 
 static void d68000_move_16(void)
 {
-	char* str = get_ea_mode_str_16(g_cpu_ir);
-	sprintf(g_dasm_str, "move.w  %s, %s", str, get_ea_mode_str_16(((g_cpu_ir>>9) & 7) | ((g_cpu_ir>>3) & 0x38)));
+	build_ea_ea(M68K_INS_MOVE, 2);
+	//char* str = get_ea_mode_str_16(g_cpu_ir);
+	//sprintf(g_dasm_str, "move.w  %s, %s", str, get_ea_mode_str_16(((g_cpu_ir>>9) & 7) | ((g_cpu_ir>>3) & 0x38)));
 }
 
 static void d68000_move_32(void)
 {
-	char* str = get_ea_mode_str_32(g_cpu_ir);
-	sprintf(g_dasm_str, "move.l  %s, %s", str, get_ea_mode_str_32(((g_cpu_ir>>9) & 7) | ((g_cpu_ir>>3) & 0x38)));
+	build_ea_ea(M68K_INS_MOVE, 4);
+	//char* str = get_ea_mode_str_32(g_cpu_ir);
+	//sprintf(g_dasm_str, "move.l  %s, %s", str, get_ea_mode_str_32(((g_cpu_ir>>9) & 7) | ((g_cpu_ir>>3) & 0x38)));
 }
 
 static void d68000_movea_16(void)

--- a/tests/test_m68k.c
+++ b/tests/test_m68k.c
@@ -121,7 +121,7 @@ end:
 static void test()
 {
 	size_t size;
-	void* code = loadToMemory("/Users/danielcollin/code/capstone_m68k_test/m68k_test.bin", &size);
+	void* code = loadToMemory("../u/m68k.bin", &size);
 	printf("size %d\n", (int)size);
 
 //#define M68K_CODE "\x4E\x71\x22\x00\x4E\x75"
@@ -139,7 +139,7 @@ static void test()
 		},
 	};
 
-	uint64_t address = 0x0000;
+	uint64_t address = 0x030672;
 	cs_insn *insn;
 	int i;
 	size_t count;


### PR DESCRIPTION
Introduce a new build_ea_ea() function aim to decode two effective address
mode operators.