### PR TITLE
[M68K] fixup issue on build_ea_a() decoding 1st op

### DIFF
--- a/arch/M68K/M68Kdasm.c
+++ b/arch/M68K/M68Kdasm.c
@@ -1084,7 +1084,7 @@ static void build_ea_a(int opcode, uint8_t size)
 	cs_m68k_op* op0 = &info->operands[0];
 	cs_m68k_op* op1 = &info->operands[1];
 
-	get_ea_mode_op(op1, g_cpu_ir, size);
+	get_ea_mode_op(op0, g_cpu_ir, size);
 
 	op1->address_mode = M68K_RD_ADDRESS;
 	op1->reg = M68K_REG_A0 + ((g_cpu_ir >> 9) & 7);


### PR DESCRIPTION
The following code will be badly decoded due to a bad variable reference
during the call of get_ea_mode_op()

0x43 0xf9 0x00 0x03 0x75 0x54

bad decoding :     lea.l d-1,a1
correct decoding : lea.l $37554.l,a1

Signed-off-by: Nicolas PLANEL <nplanel@gmail.com>